### PR TITLE
Update to newer META spec

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@ use warnings;
 
 use ExtUtils::MakeMaker qw( WriteMakefile );
 
-my %build_requires = (
+my %test_requires = (
     'Test::More'      => 0,  # For testing.
     'Test::Exception' => 0,  # For testing.
 );
@@ -13,9 +13,9 @@ WriteMakefile(
     VERSION_FROM  => 'lib/Convert/Base32.pm',
     ABSTRACT_FROM => 'lib/Convert/Base32.pm',
 
-    ( $ExtUtils::MakeMaker::VERSION lt '6.56'
-	? ( PREREQ_PM      => \%build_requires )
-	: ( BUILD_REQUIRES => \%build_requires )
+    ( "$ExtUtils::MakeMaker::VERSION" >= 6.64 ? ( TEST_REQUIRES  => \%test_requires )
+    : "$ExtUtils::MakeMaker::VERSION" >= 6.56 ? ( BUILD_REQUIRES => \%test_requires )
+    :                                           ( PREREQ_PM      => \%test_requires )
     ),
 
     dist  => { COMPRESS => 'gzip -9f' },


### PR DESCRIPTION
This properly declares the test dependencies as such, given a non-ancient MakeMaker.