### PR TITLE
Remove indirect Sub::Uplevel dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@ use warnings;
 
 use ExtUtils::MakeMaker qw( WriteMakefile );
 
-my %build_requires = (
+my %test_requires = (
     'Test::More'      => 0,  # For testing.
     'Test::Exception' => 0,  # For testing.
 );
@@ -13,9 +13,9 @@ WriteMakefile(
     VERSION_FROM  => 'lib/Convert/Base32.pm',
     ABSTRACT_FROM => 'lib/Convert/Base32.pm',
 
-    ( $ExtUtils::MakeMaker::VERSION lt '6.56'
-	? ( PREREQ_PM      => \%build_requires )
-	: ( BUILD_REQUIRES => \%build_requires )
+    ( "$ExtUtils::MakeMaker::VERSION" >= 6.64 ? ( TEST_REQUIRES  => \%test_requires )
+    : "$ExtUtils::MakeMaker::VERSION" >= 6.56 ? ( BUILD_REQUIRES => \%test_requires )
+    :                                           ( PREREQ_PM      => \%test_requires )
     ),
 
     dist  => { COMPRESS => 'gzip -9f' },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,6 @@ use ExtUtils::MakeMaker qw( WriteMakefile );
 
 my %test_requires = (
     'Test::More'      => 0,  # For testing.
-    'Test::Exception' => 0,  # For testing.
 );
 
 WriteMakefile(

--- a/t/01_error_checks.t
+++ b/t/01_error_checks.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 
 use Test::More;
-use Test::Exception;
 
 use Convert::Base32 qw( encode_base32 decode_base32 );
 
@@ -36,10 +35,14 @@ my @tests = (
 
 plan tests => 2*@tests + 2*512;
 
+sub   dies_ok (&;$) { eval { shift->(); &fail } or &pass }
+sub  lives_ok (&;$) { eval { shift->(); &pass } or &fail }
+sub lives_and (&;$) { eval { shift->(@_) } or &fail }
+
 for (@tests) {
     my ($e, $dlen) = @$_;
     if ($dlen =~ /^[0-9]+\z/) {
-        lives_and { is length(decode_base32($e)), $dlen } "$e (ok)";
+        lives_and { is length(decode_base32($e)), $dlen, shift } "$e (ok)";
     } else {
         dies_ok { decode_base32($e) } "$e ($dlen)";
     }
@@ -49,7 +52,7 @@ for (@tests) {
     my ($e, $dlen) = @$_;
     $e = "aaaaaaaa$e";
     if ($dlen =~ /^[0-9]+\z/) {
-	lives_and { is length(decode_base32($e)), 5+$dlen } "$e (ok)";
+	lives_and { is length(decode_base32($e)), 5+$dlen, shift } "$e (ok)";
     } else {
 	dies_ok { decode_base32($e) } "$e ($dlen)";
     }


### PR DESCRIPTION
Test::Exception goes to unnecessary lengths to hide its presence from the code it calls, including pulling in Sub::Uplevel. None of that is necessary for this module, so this patch removes those dependencies by reimplementing its helpers in 3 lines of code. This also leaves Convert::Base32 with only core dependencies.